### PR TITLE
Allow customising the deploy messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,33 @@ env:
   CI_JOB_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}
 ```
 
+## Customise deploy messages
+
+You can choose to customise the deploy messages globally or per project. If you set both, the project config will take precedence. For each task (deploy start or deploy success) you can customise two elements: `text` and `colour`.
+
+To set globally, in `group_vars/all/helpers.yml`:
+
+```yaml
+slack_notify:
+  deploy_start_text: "has started deploying 🌱"
+  deploy_start_colour: "normal" # see https://docs.ansible.com/ansible/latest/collections/community/general/slack_module.html#parameter-color for accepted colours.
+  deploy_success_text: "has successfully deployed 🌿"
+  deploy_success_colour: "good"
+```
+
+To set per project, in `group_vars/{environment}/wordpress_sites.yml`
+
+```yaml
+wordpress_sites:
+  example.com.au:
+    slack_notify:
+      deploy_start_text: "is kicking up code from"
+```
+
+With both of the above examples set, the deploy start message would be taken from the project config:
+
+> **Dale Grant** is kicking up code from `master` to **example.com.au staging**
+
 ## FAQs
 
 ### How do I get a Slack Webhook URL?

--- a/tasks/deploy_start.yml
+++ b/tasks/deploy_start.yml
@@ -1,7 +1,7 @@
 ---
 - name: Load vars
   include_vars:
-    file: "{{ playbook_dir }}/vendor/roles/slack-notify/vars/main.yml"
+    file: "{{ playbook_dir }}/vendor/roles/trellis-slack-deploy-notifications/vars/main.yml"
 
 - name: Set ENV & Git vars
   set_fact:

--- a/tasks/deploy_start.yml
+++ b/tasks/deploy_start.yml
@@ -1,4 +1,8 @@
 ---
+- name: Load vars
+  include_vars:
+    file: "{{ playbook_dir }}/vendor/roles/slack-notify/vars/main.yml"
+
 - name: Set ENV & Git vars
   set_fact:
     git_username: "{{ lookup('pipe', 'git config user.name') }}"
@@ -11,8 +15,8 @@
   slack:
     token: "{{ slack_deploy_token }}"
     attachments:
-      - text: "*{{ git_username }}* deploying 🔀`{{ branch_name }}` to *<{{ target_env_url }}>* {% if ci_job_url | length > 0 %}[<{{ ci_job_url }}|🔎>]{% endif %}"
-        color: warning
+      - text: "*{{ git_username }}* {{ slack_notify_config.deploy_start_text }} `{{ branch_name }}` to *<{{ target_env_url }}>* {% if ci_job_url | length > 0 %}[<{{ ci_job_url }}|🔎>]{% endif %}"
+        color: "{{ slack_notify_config.deploy_start_colour }}"
   with_items: "{{ vault_wordpress_sites[site].slack_deploy_token }}"
   loop_control:
     loop_var: slack_deploy_token

--- a/tasks/deploy_success.yml
+++ b/tasks/deploy_success.yml
@@ -27,8 +27,8 @@
   slack:
     token: "{{ slack_deploy_token }}"
     attachments:
-      - text: "*{{ git_username }}* deployed 🔀`{{ branch_name }}` to *<{{ target_env_url }}>* [{{ commit_sha }}]"
-        color: good
+      - text: "*{{ git_username }}* {{ slack_notify_config.deploy_success_text }} `{{ branch_name }}` to *<{{ target_env_url }}>* [{{ commit_sha }}]"
+        color: "{{ slack_notify_config.deploy_success_colour }}"
   with_items: "{{ vault_wordpress_sites[site].slack_deploy_token }}"
   loop_control:
     loop_var: slack_deploy_token

--- a/tasks/deploy_success.yml
+++ b/tasks/deploy_success.yml
@@ -1,7 +1,7 @@
 ---
 - name: Load vars
   include_vars:
-    file: "{{ playbook_dir }}/vendor/roles/slack-notify/vars/main.yml"
+    file: "{{ playbook_dir }}/vendor/roles/trellis-slack-deploy-notifications/vars/main.yml"
 
 - name: Set ENV & Git vars
   set_fact:

--- a/tasks/deploy_success.yml
+++ b/tasks/deploy_success.yml
@@ -1,4 +1,8 @@
 ---
+- name: Load vars
+  include_vars:
+    file: "{{ playbook_dir }}/vendor/roles/slack-notify/vars/main.yml"
+
 - name: Set ENV & Git vars
   set_fact:
     git_username: "{{ lookup('pipe', 'git config user.name') }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,7 @@
+slack_notify_config_default:
+  deploy_start_text: "deploying 🔀"
+  deploy_start_colour: "warning"
+  deploy_success_text: "deployed 🔀"
+  deploy_success_colour: "good"
+
+slack_notify_config: "{{ slack_notify_config_default | combine(slack_notify | combine(project.slack_notify | default({}))) }}"


### PR DESCRIPTION
Rel: smithfield-studio/trellis-slack-deploy-notifications#7

## Customise deploy messages

You can choose to customise the deploy messages globally or per project. If you set both, the project config will take precedence. For each task (deploy start or deploy success) you can customise two elements: `text` and `colour`.

To set globally, in `group_vars/all/helpers.yml`:

```yaml
slack_notify:
  deploy_start_text: "has started deploying 🌱"
  deploy_start_colour: "normal" # see https://docs.ansible.com/ansible/latest/collections/community/general/slack_module.html#parameter-color for accepted colours.
  deploy_success_text: "has successfully deployed 🌿"
  deploy_success_colour: "good"
```

To set per project, in `group_vars/{environment}/wordpress_sites.yml`

```yaml
wordpress_sites:
  example.com.au:
    slack_notify:
      deploy_start_text: "is kicking up code from"
```

With both of the above examples set, the deploy start message would be taken from the project config:

> **Dale Grant** is kicking up code from `master` to **example.com.au staging**