### PR TITLE
Prefer project_version over current git repo branch name

### DIFF
--- a/tasks/deploy_start.yml
+++ b/tasks/deploy_start.yml
@@ -6,7 +6,6 @@
 - name: Set ENV & Git vars
   set_fact:
     git_username: "{{ lookup('pipe', 'git config user.name') }}"
-    branch_name: "{{ lookup('pipe', 'git branch --show-current') }}"
     target_env_url: "https://{{ project.site_hosts | map(attribute='canonical') | first }}|{{ site }} {{ env }}"
     ci_job_url: "{{ lookup('env', 'CI_JOB_URL') }}"
   ignore_errors: yes
@@ -15,7 +14,7 @@
   slack:
     token: "{{ slack_deploy_token }}"
     attachments:
-      - text: "*{{ git_username }}* {{ slack_notify_config.deploy_start_text }} `{{ branch_name }}` to *<{{ target_env_url }}>* {% if ci_job_url | length > 0 %}[<{{ ci_job_url }}|🔎>]{% endif %}"
+      - text: "*{{ git_username }}* {{ slack_notify_config.deploy_start_text }} `{{ project_version }}` to *<{{ target_env_url }}>* {% if ci_job_url | length > 0 %}[<{{ ci_job_url }}|🔎>]{% endif %}"
         color: "{{ slack_notify_config.deploy_start_colour }}"
   with_items: "{{ vault_wordpress_sites[site].slack_deploy_token }}"
   loop_control:

--- a/tasks/deploy_success.yml
+++ b/tasks/deploy_success.yml
@@ -6,7 +6,6 @@
 - name: Set ENV & Git vars
   set_fact:
     git_username: "{{ lookup('pipe', 'git config user.name') }}"
-    branch_name: "{{ lookup('pipe', 'git branch --show-current') }}"
     target_env_url: "https://{{ project.site_hosts | map(attribute='canonical') | first }}|{{ site }} {{ env }}"
     commit_sha: "{{ git_clone.after }}"
     using_github: "{{ project_git_repo.find('github') != -1 }}"
@@ -31,7 +30,7 @@
   slack:
     token: "{{ slack_deploy_token }}"
     attachments:
-      - text: "*{{ git_username }}* {{ slack_notify_config.deploy_success_text }} `{{ branch_name }}` to *<{{ target_env_url }}>* [{{ commit_sha }}]"
+      - text: "*{{ git_username }}* {{ slack_notify_config.deploy_success_text }} `{{ project_version }}` to *<{{ target_env_url }}>* [{{ commit_sha }}]"
         color: "{{ slack_notify_config.deploy_success_colour }}"
   with_items: "{{ vault_wordpress_sites[site].slack_deploy_token }}"
   loop_control:


### PR DESCRIPTION
Hey @mike-sheppard I noticed that the branch names were incorrect for us. We have Trellis and Bedrock in separate repos, so grabbing the current git branch would return the Trellis branch, _not_ the Bedrock branch. 

This should be fixable by using an existing var within Trellis `{{ project_version }}`. ([Link to var in Trellis](https://github.com/roots/trellis/blob/f9b770be5eb3d58cee4c9d26215ac913b31a47d3/roles/deploy/defaults/main.yml#L5)). This fetches the project branch [set in wordpress_sites.yml](https://github.com/roots/trellis/blob/f9b770be5eb3d58cee4c9d26215ac913b31a47d3/group_vars/production/wordpress_sites.yml#L14) (or the one that's set using your own method 🤯 [here](https://github.com/roots/trellis-cli/issues/125))

Otherwise we're permanently deploying `master` 😅 