### PR TITLE
Fix: No dependency on custom message config

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,4 +4,4 @@ slack_notify_config_default:
   deploy_success_text: "deployed 🔀"
   deploy_success_colour: "good"
 
-slack_notify_config: "{{ slack_notify_config_default | combine(slack_notify | combine(project.slack_notify | default({}))) }}"
+slack_notify_config: "{{ slack_notify_config_default | combine(slack_notify | default({}) | combine(project.slack_notify | default({})) ) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,4 +4,4 @@ slack_notify_config_default:
   deploy_success_text: "deployed 🔀"
   deploy_success_colour: "good"
 
-slack_notify_config: "{{ slack_notify_config_default | combine(slack_notify | default({}) | combine(project.slack_notify | default({})) ) }}"
+slack_notify_config: "{{ slack_notify_config_default | combine( (slack_notify | default({})) | combine(project.slack_notify | default({})) ) }}"


### PR DESCRIPTION
The message customising feature added by @dalepgrant in #9 is amazing! 🎉
It works great, but with the current implementation, it requires us to add the `slack_notify` config manually in every project, as the role fails otherwise with a `slack_notify is undefined` error during deployment. 

Looking at the code, it seems like it was just missing a default fallback. This PR adds that, and it should fix the `slack_notify is undefined` error when no manual config is set.

Would love to hear any feedback on this! 🙏